### PR TITLE
Move default Redis connection string out of CD spec into secret

### DIFF
--- a/k8s/sxp/10.0/ltsc2019/xm1/cd.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xm1/cd.yaml
@@ -89,7 +89,10 @@ spec:
               name: sitecore-solr
               key: sitecore-solr-connection-string.txt
         - name: Sitecore_ConnectionStrings_Redis.Sessions
-          value: redis:6379,ssl=False,abortConnect=False
+          valueFrom:
+            secretKeyRef:
+              name: sitecore-redis
+              key: sitecore-redis-connection-string.txt
         - name: SOLR_CORE_PREFIX_NAME
           valueFrom:
             secretKeyRef:

--- a/k8s/sxp/10.0/ltsc2019/xm1/secrets/kustomization.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xm1/secrets/kustomization.yaml
@@ -35,6 +35,9 @@ secretGenerator:
   files:
   - sitecore-solr-connection-string.txt
   - sitecore-solr-core-prefix-name.txt
+- name: sitecore-redis
+  files:
+  - sitecore-redis-connection-string.txt
 - name: global-cd-tls
   files:
     - tls/global-cd/tls.key

--- a/k8s/sxp/10.0/ltsc2019/xm1/secrets/sitecore-redis-connection-string.txt
+++ b/k8s/sxp/10.0/ltsc2019/xm1/secrets/sitecore-redis-connection-string.txt
@@ -1,0 +1,1 @@
+redis:6379,ssl=False,abortConnect=False

--- a/k8s/sxp/10.0/ltsc2019/xp1/cd.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xp1/cd.yaml
@@ -134,7 +134,10 @@ spec:
         - name: Sitecore_ConnectionStrings_Xdb.ReferenceData.Client
           value: http://xdbrefdata
         - name: Sitecore_ConnectionStrings_Redis.Sessions
-          value: redis:6379,ssl=False,abortConnect=False
+          valueFrom:
+            secretKeyRef:
+              name: sitecore-redis
+              key: sitecore-redis-connection-string.txt
         - name: SOLR_CORE_PREFIX_NAME
           valueFrom:
             secretKeyRef:

--- a/k8s/sxp/10.0/ltsc2019/xp1/secrets/kustomization.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xp1/secrets/kustomization.yaml
@@ -61,6 +61,9 @@ secretGenerator:
 - name: sitecore-solr-xdb
   files:
   - sitecore-solr-connection-string-xdb.txt
+- name: sitecore-redis
+  files:
+  - sitecore-redis-connection-string.txt
 - name: global-cd-tls
   files:
     - tls/global-cd/tls.key

--- a/k8s/sxp/10.0/ltsc2019/xp1/secrets/sitecore-redis-connection-string.txt
+++ b/k8s/sxp/10.0/ltsc2019/xp1/secrets/sitecore-redis-connection-string.txt
@@ -1,0 +1,1 @@
+redis:6379,ssl=False,abortConnect=False


### PR DESCRIPTION
The Kubernetes specification files as provided contain a hard-coded connection string to Redis. You can of course change it in there (the cd.yaml spec file in your repo), but I think it is more elegant to remove the value from the specification files and place it inside a secrets file, as is being done with the Solr connection string. This makes the spec file implementation-agnostic, easier to upgrade and not containing environment specific variables / parameters. Subsequently, you can choose to retrieve this connection string value either from an Azure DevOps Variable group, or by using a secret from your Azure KeyVault instance for example, to inject the correct value in the secrets file at provisioning-time.

I also mentioned this in my blog post https://www.robhabraken.nl/index.php/3619/paas-to-aks-arm-for-eds/, this is the corresponding Pull Request of said change to the spec files.