### PR TITLE
Added ingress.class now required by Nginx Ingress Controller

### DIFF
--- a/k8s/sxp/10.0/ltsc2019/xm1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xm1/ingress-nginx/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost

--- a/k8s/sxp/10.0/ltsc2019/xp1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.0/ltsc2019/xp1/ingress-nginx/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost

--- a/k8s/sxp/10.1/ltsc2019/xm1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xm1/ingress-nginx/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost

--- a/k8s/sxp/10.1/ltsc2019/xp1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xp1/ingress-nginx/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost

--- a/sxc/10.0/k8s-commerce-xc1/ingress-nginx/ingress.yaml
+++ b/sxc/10.0/k8s-commerce-xc1/ingress-nginx/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost

--- a/sxc/10.1/k8s-commerce-xc1/ingress-nginx/ingress.yaml
+++ b/sxc/10.1/k8s-commerce-xc1/ingress-nginx/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: cd.globalhost


### PR DESCRIPTION
Since v1.0.0 Nginx Ingress Controller, it now requires `ingress.class` to be specified on Ingresses definitions.

This PR adds this notation to all ingress definitions for the different Sitecore versions & Topologies.

More details here: https://robearlam.com/blog/nginx-ingress-breaking-change-ingress.class-now-required