### PR TITLE
Update CODEOWNERS - add Dennis Doorn

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 # The files in the `/sxc/` directory are only expected
 # to be updated by sxc team. Setting CODEOWNER to
 # sxc team members.
-/sxc/ @sc-marklee @sc-marcusheath
+/sxc/ @sc-marklee @sc-marcusheath @ddoorn
 
 # The folders /compose/ and /k8s/ contains Container Support Package files
 # Each team publishing Container Support Packages will add code owner(s) for their repective folders


### PR DESCRIPTION
Please approve adding Dennis Doorn so he can approve PR requests for releasing XC Container SDK updates.  Dennis will replace Mark Lee in this XC task. Thanks.  Dennis will use account ddoorn which complies with the private GitHub user instructions posted in Confluence.