### PR TITLE
Add codeowners of publishing to xm-onprem team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,8 +24,9 @@
 
 /k8s/expedge/            @Sitecore/content-foundation-kl
 /compose/expedge/        @Sitecore/content-foundation-kl
-/k8s/publishing/         @Sitecore/content-foundation-kl
-/compose/publishing/     @Sitecore/content-foundation-kl
+
+/k8s/publishing/         @Sitecore/content-foundation-kl @Sitecore/xm-onprem
+/compose/publishing/     @Sitecore/content-foundation-kl @Sitecore/xm-onprem
 
 /compose/horizon/        @Sitecore/horizon
 /k8s/horizon/            @Sitecore/horizon


### PR DESCRIPTION
Add codeowners of publishing to xm-onprem team as the component maintaining moves to the team