### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 # The files in the `/sxc/` directory are only expected
 # to be updated by sxc team. Setting CODEOWNER to
 # sxc team members.
-/sxc/ @sc-marklee @sc-marcusheath @ddoorn
+/sxc/ @sc-marklee @sc-marcusheath @ddoorn @sc-roblloyd @sc-ketanbhavsar
 
 # The folders /compose/ and /k8s/ contains Container Support Package files
 # Each team publishing Container Support Packages will add code owner(s) for their repective folders


### PR DESCRIPTION
Adding Rob Lloyd and Ketan Bhavsar as code owners for approving SXC Engine container SDK releases.