### PR TITLE
Update 10.1 SXP Sitecore Container Deployment to 10.1.3.009558.1562

### DIFF
--- a/k8s/sxp/10.1/ltsc2019/xm1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xm1/ingress-nginx/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: sitecore-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/rewrite-target: /
@@ -12,6 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
 spec:
+  ingressClassName: "nginx"
   rules:
   - host: cd.globalhost
     http:

--- a/k8s/sxp/10.1/ltsc2019/xm1/kustomization.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xm1/kustomization.yaml
@@ -9,7 +9,7 @@ images:
   newTag: 10.1-ltsc2019
 - name: sitecore-xm1-id
   newName: scr.sitecore.com/sxp/sitecore-id7
-  newTag: 10.1.3-ltsc2019
+  newTag: 10.1-ltsc2019
 resources:
 - cm.yaml
 - cd.yaml

--- a/k8s/sxp/10.1/ltsc2019/xm1/overlays/init/SearchStax/kustomization.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xm1/overlays/init/SearchStax/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
 - ..\..\..\init
 patchesStrategicMerge:
 - solr-init.yaml

--- a/k8s/sxp/10.1/ltsc2019/xp1/ingress-nginx/ingress.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xp1/ingress-nginx/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: sitecore-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/rewrite-target: /
@@ -12,6 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "512m"
 spec:
+  ingressClassName: "nginx"
   rules:
   - host: cd.globalhost
     http:

--- a/k8s/sxp/10.1/ltsc2019/xp1/kustomization.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xp1/kustomization.yaml
@@ -9,7 +9,7 @@ images:
   newTag: 10.1-ltsc2019
 - name: sitecore-xp1-id
   newName: scr.sitecore.com/sxp/sitecore-id7
-  newTag: 10.1.3-ltsc2019
+  newTag: 10.1-ltsc2019
 - name: sitecore-xp1-cortexprocessing
   newName: scr.sitecore.com/sxp/sitecore-xp1-cortexprocessing
   newTag: 10.1-ltsc2019

--- a/k8s/sxp/10.1/ltsc2019/xp1/overlays/init/SearchStax/kustomization.yaml
+++ b/k8s/sxp/10.1/ltsc2019/xp1/overlays/init/SearchStax/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
 - ..\..\..\init
 patchesStrategicMerge:
 - solr-init.yaml


### PR DESCRIPTION
Update release of SXP Sitecore Container Deployment 10.1 (10.1.3.009558.1562)

Release notes:

- Replaced 'bases' with 'resources' in specifications for full AKS 1.27 compatibility.
- Updated short tags in specifications for consistency.